### PR TITLE
Migrate forcefully to passthru interactive mode

### DIFF
--- a/docker/php/init.sh
+++ b/docker/php/init.sh
@@ -16,7 +16,7 @@ echo "[info] Waiting for mysql"
 sleep 10
 
 echo "[info] Migrating database"
-php /var/www/artisan migrate || true
+php /var/www/artisan migrate --force || true
 
 echo "Run: $@"
 exec "$@"


### PR DESCRIPTION
Changing `APP_ENV` from `local` to `production` forces interactive mode while running migrations. So instead of interactive mode just migrate forcefully.

Fixes #11 

